### PR TITLE
translate hurricane function was missing site argument

### DIFF
--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -380,7 +380,7 @@ class SfincsAdapter:
         """
 
         historical_hurricane.make_spw_file(
-            database_path=database_path, model_dir=model_dir
+            database_path=database_path, model_dir=model_dir, site=self.site
         )
 
     def set_config_spw(self, spw_name: str):

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -613,9 +613,6 @@ class Hazard:
                     const_dir=self.event.attrs.wind.constant_direction.value,
                 )
         elif self.event.attrs.template == "Historical_hurricane":
-            logging.info(
-                "Generating meteo input to the model from the hurricane track..."
-            )
             spw_name = "hurricane.spw"
             offshore_model.set_config_spw(spw_name=spw_name)
 
@@ -623,11 +620,15 @@ class Hazard:
         offshore_model.write_sfincs_model(path_out=self.simulation_paths_offshore[ii])
 
         if self.event.attrs.template == "Historical_hurricane":
+            logging.info(
+                "Generating meteo input to the model from the hurricane track..."
+            )
             offshore_model.add_spw_forcing(
                 historical_hurricane=self.event,
                 database_path=base_path,
                 model_dir=self.simulation_paths_offshore[ii],
             )
+            logging.info("Finished generating meteo data from hurricane track.")
 
     def postprocess_sfincs_offshore(self, ii: int):
         # Initiate offshore model


### PR DESCRIPTION
The function to translate hurricanes was missing the argument site because it was not passed by the SfincsAdapter. Minor fix thus